### PR TITLE
pdate getUserShifts to limit default range to current month up to today

### DIFF
--- a/back/controllers/userShiftsController.js
+++ b/back/controllers/userShiftsController.js
@@ -15,7 +15,7 @@ export const getUserShifts = async (req, res) => {
     } else {
       const now = DateTime.now().setZone("America/Argentina/Buenos_Aires");
       startDate = now.startOf("month").toJSDate();
-      endDate = now.endOf("month").toJSDate();
+      endDate = now.endOf("day").toJSDate(); // solo hasta el día de hoy
     }
 
     const result = await pool.query(

--- a/front/src/components/user-calendar/UserShiftsCalendar.jsx
+++ b/front/src/components/user-calendar/UserShiftsCalendar.jsx
@@ -36,7 +36,7 @@ export default function UserShiftsCalendar({ onMonthChange, userId, title = "Tur
       );
 
   return (
-    <section className="p-6" aria-label="Calendario de turnos">
+    <section className="p-6 " aria-label="Calendario de turnos">
       <h2 className="text-2xl font-bold mb-4">{title}</h2>
         <div className="rounded-lg p-4 shadow-lg border border-gray-200 bg-[var(--color-primary)] overflow-hidden">
           <div

--- a/front/src/components/user-card/UserCard.jsx
+++ b/front/src/components/user-card/UserCard.jsx
@@ -16,7 +16,7 @@ export default function UserCard({ user }) {
   navigate(`/users/${user.id}/summary`);
 };
   return (
-    <div className="bg-white p-4 rounded-lg shadow-md flex flex-col items-start space-y-4 cursor-pointer"
+    <div className="bg-white border-2 border-gray-100 p-4 rounded-lg shadow-md flex flex-col items-start space-y-4 cursor-pointer"
       onClick={handleClick}>
       <div className="flex items-center space-x-4">
         <span className="text-4xl">{emoji}</span>

--- a/front/src/components/user-detail/UserDetailCard.jsx
+++ b/front/src/components/user-detail/UserDetailCard.jsx
@@ -2,8 +2,8 @@ import PropTypes from "prop-types";
 
 export default function UserDetailCard({ user, summary }) {
   return (
-    <section aria-label="Información del usuario" className="flex flex-row gap-4 items-stretch w-full">
-      <article className="flex-1 bg-[#fafae0] shadow rounded p-6 flex flex-col justify-between min-h-[220px]" aria-label="Datos personales">
+    <section aria-label="Información del usuario" className="flex flex-row gap-4    items-stretch w-full">
+      <article className="flex-1 border-2 border-gray-100 bg-[#fafae0] shadow rounded p-6 flex flex-col justify-between min-h-[220px]" aria-label="Datos personales">
         <h2 className="text-xl font-semibold mb-4">Datos del Usuario</h2>
         <div>
           <p>
@@ -20,7 +20,7 @@ export default function UserDetailCard({ user, summary }) {
           </p>
         </div>
       </article>
-      <article className="flex-1 bg-blue-50 shadow rounded p-6 flex flex-col justify-between min-h-[220px]" aria-label="Estadísticas del mes actual">
+      <article className="flex-1  border-2 border-gray-100  bg-blue-50 shadow rounded p-6 flex flex-col justify-between min-h-[220px]" aria-label="Estadísticas del mes actual">
         <h2 className="text-xl font-semibold mb-4">Estadísticas del Mes Actual</h2>
         <div>
           <p>


### PR DESCRIPTION
Modified the controller logic to return user shifts from the beginning of the current month up to the current day when no custom date range is provided. This prevents future dates from being included in the response and improves accuracy for monthly reports.